### PR TITLE
feat: Add Makefile and security testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,15 @@ dist
 
 # Container Structure Test binary
 container-structure-test-linux-amd64
+
+# Security test results
+trivy-results.json
+hadolint-results.json
+dockle-results.json
+
+# Security tools and results
+.tools/
+.trivy-cache/
+trivy-results.json
+hadolint-results.json
+dockle-results.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,11 @@ RUN npm install -g corepack@0.24.1 && \
     corepack enable pnpm && \
     corepack enable yarn
     
-RUN npm install -g \
-    jest@29.7.0 \
-    mocha@10.3.0 \
-    chai@5.1.0 \
-    ts-node@10.9.2 \
-    eslint@8.57.0 \
-    prettier@3.2.5 \
-    @typescript-eslint/parser@7.1.1 \
-    @typescript-eslint/eslint-plugin@7.1.1 \
-    @types/jest@29.5.12 \
-    @types/mocha@10.0.6 \
-    @types/chai@4.3.12 \
-    source-map-support@0.5.21 \
-    pm2@5.3.1 \
-    typescript@5.4.2 \
-    zx@7.2.3 \
-    dotenv-cli@7.3.0 \
-    cross-env@7.0.3 \
-    http-server@14.1.1 \
-    localtunnel@2.0.2
+
+COPY package.json /tmp/package.json
+
+RUN cd /tmp && \
+    npm install -g $(node -p "Object.entries(require('./package.json').dependencies).map(([pkg, ver]) => pkg + '@' + ver).join(' ')")
+
+RUN rm /tmp/package.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+.PHONY: test install-deps clean build
+
+# Variables
+IMAGE_NAME = playwright-plus
+TEST_TAG = test-security
+CONTAINER_TEST_VERSION = latest
+HADOLINT_VERSION = v2.12.0
+TOOLS_DIR = .tools
+PLATFORM = $(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m)
+
+# Install all test dependencies
+install-deps:
+	@echo "Installing test dependencies..."
+	@mkdir -p $(TOOLS_DIR)
+	
+	# Install container-structure-test
+	@if [ ! -f $(TOOLS_DIR)/container-structure-test ]; then \
+		curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && \
+		chmod +x container-structure-test-linux-amd64 && \
+		mv container-structure-test-linux-amd64 $(TOOLS_DIR)/container-structure-test; \
+	fi
+	
+	# Install Trivy
+	@if [ ! -f $(TOOLS_DIR)/trivy ]; then \
+		TRIVY_VERSION=$$(curl -s "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
+		curl -L -o $(TOOLS_DIR)/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v$${TRIVY_VERSION}/trivy_$${TRIVY_VERSION}_Linux-64bit.tar.gz && \
+		tar -xzf $(TOOLS_DIR)/trivy.tar.gz -C $(TOOLS_DIR) trivy && \
+		rm $(TOOLS_DIR)/trivy.tar.gz && \
+		chmod +x $(TOOLS_DIR)/trivy; \
+	fi
+	
+	# Install Hadolint
+	@if [ ! -f $(TOOLS_DIR)/hadolint ]; then \
+		curl -L -o $(TOOLS_DIR)/hadolint https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VERSION)/hadolint-Linux-x86_64 && \
+		chmod +x $(TOOLS_DIR)/hadolint; \
+	fi
+	
+	# Install Dockle
+	@if [ ! -f $(TOOLS_DIR)/dockle ]; then \
+		VERSION=$$(curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
+		curl -L -o $(TOOLS_DIR)/dockle.tar.gz https://github.com/goodwithtech/dockle/releases/download/v$${VERSION}/dockle_$${VERSION}_Linux-64bit.tar.gz && \
+		tar -xzf $(TOOLS_DIR)/dockle.tar.gz -C $(TOOLS_DIR) dockle && \
+		rm $(TOOLS_DIR)/dockle.tar.gz && \
+		chmod +x $(TOOLS_DIR)/dockle; \
+	fi
+
+# Build the Docker image
+build:
+	@echo "Building Docker image..."
+	docker build -t $(IMAGE_NAME):$(TEST_TAG) .
+
+# Run all security tests
+test: build
+	@echo "Running security tests..."
+	@mkdir -p $(TOOLS_DIR)/.trivy-cache
+	
+	@echo "\n=== Running Trivy scan ==="
+	-$(TOOLS_DIR)/trivy image --cache-dir $(TOOLS_DIR)/.trivy-cache --format json --output trivy-results.json --ignore-unfixed --vuln-type os,library --severity CRITICAL,HIGH $(IMAGE_NAME):$(TEST_TAG)
+	
+	@echo "\n=== Running Hadolint ==="
+	-$(TOOLS_DIR)/hadolint --format json Dockerfile > hadolint-results.json
+	
+	@echo "\n=== Running Dockle ==="
+	-$(TOOLS_DIR)/dockle --format json --output dockle-results.json --ignore CIS-DI-0001 $(IMAGE_NAME):$(TEST_TAG)
+	
+	@echo "\n=== Running Container Structure Tests ==="
+	-$(TOOLS_DIR)/container-structure-test test --image $(IMAGE_NAME):$(TEST_TAG) --config .container-structure-test.yaml
+	
+	@echo "\n=== Test Summary ==="
+	@echo "Trivy vulnerabilities: $$(jq '.Results[].Vulnerabilities | length // 0' trivy-results.json | jq -s 'add // 0')"
+	@echo "Hadolint issues: $$(jq '. | length // 0' hadolint-results.json)"
+	@echo "Dockle warnings: $$(jq '.Failures | length // 0' dockle-results.json)"
+
+# Clean up test artifacts
+clean:
+	@echo "Cleaning up..."
+	rm -rf $(TOOLS_DIR)
+	rm -f trivy-results.json
+	rm -f hadolint-results.json
+	rm -f dockle-results.json
+	docker rmi $(IMAGE_NAME):$(TEST_TAG) || true 


### PR DESCRIPTION
- Introduce comprehensive Makefile for security testing
- Add .gitignore entries for security test results and tools
- Modify Dockerfile to dynamically install global npm packages from package.json
- Implement automated security scanning with Trivy, Hadolint, Dockle, and Container Structure Tests
- Create tool installation and test execution targets in Makefile