### PR TITLE
feat: Enhance Docker build and test infrastructure for multi-version …

### DIFF
--- a/.container-structure-test.yaml
+++ b/.container-structure-test.yaml
@@ -38,6 +38,10 @@ commandTests:
   - name: 'PNPM Availability'
     command: 'pnpm'
     args: ['--version']
+  - name: 'Java availability'
+    command: 'java'
+    args: ['--version']
+    expectedOutput: ['OpenJDK Runtime Environment']
 
 metadataTest:
   envVars: []

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,74 +22,62 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  generate-matrix:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # List of Playwright versions you want to build against.
-        # Update this list as needed.
-        playwright: [ "1.50.1", "1.49.1" ]
-    permissions:
-      contents: read
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
-
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Install the cosign tool (except on pull requests)
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.8.0
-        with:
-          cosign-release: 'v2.2.4'  # optional
+      - name: Generate matrix from Dockerfiles
+        id: set-matrix
+        run: |
+          # Find all Dockerfile.* files in the repository root
+          files=$(find . -maxdepth 1 -name 'Dockerfile.*' -type f)
+          echo "Found Dockerfiles:"
+          echo "$files"
+          matrix="{\"include\":["
+          sep=""
+          for file in $files; do
+            # Extract the suffix after "Dockerfile."
+            tag=$(basename "$file")
+            tag=${tag#Dockerfile.}
+            # If no tag found, use a default value
+            [ -z "$tag" ] && tag="default"
+            # Remove any leading "./"
+            dockerfile=$(echo "$file" | sed 's|^\./||')
+            matrix="$matrix$sep{\"dockerfile\":\"$dockerfile\",\"image_tag\":\"$tag\"}"
+            sep=","
+          done
+          matrix="$matrix]}"
+          echo "Generated matrix: $matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-      # Set up Docker Buildx for multi-platform builds and caching
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.9.0
+  build-and-test:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # Log into Docker registry (except on pull requests)
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Sanitize the tag name by replacing disallowed characters
       - name: Sanitize tag name
         id: sanitize
         run: |
           safe_ref=$(echo "${{ github.ref_name }}" | sed 's#[/:\_@~^ #]#-#g')
           echo "safe_ref=${safe_ref}" >> $GITHUB_OUTPUT
 
-      # Build and push Docker image for each Playwright version from the matrix.
-      # The resulting image is tagged as: <git-tag>-<playwright-version>
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build Docker image
+        id: build
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use the sanitized ref name from the previous step
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sanitize.outputs.safe_ref }}-pw${{ matrix.playwright }}
+          push: ${{ github.event_name != 'pull_request' }}  # Only push on non-PR events
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sanitize.outputs.safe_ref }}-${{ matrix.image_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: Dockerfile-pw-${{ matrix.playwright }}
           build-args: |
             PLAYWRIGHT_VERSION=${{ matrix.playwright }}
-
-      # Sign the Docker image (except on pull requests)
-      - name: Sign the published Docker image
-        if: github.event_name != 'pull_request'
-        env:
-          # Construct the tag manually as used above
-          TAGS: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sanitize.outputs.safe_ref }}-${{ matrix.playwright }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Sanitize tag name
         id: sanitize
         run: |

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -13,11 +13,43 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate matrix from Dockerfiles
+        id: set-matrix
+        run: |
+          # Find all Dockerfile.* files in the repository root
+          files=$(find . -maxdepth 1 -name 'Dockerfile.*' -type f)
+          echo "Found Dockerfiles:"
+          echo "$files"
+          matrix="{\"include\":["
+          sep=""
+          for file in $files; do
+            # Extract the suffix after "Dockerfile."
+            tag=$(basename "$file")
+            tag=${tag#Dockerfile.}
+            # If no tag found, use a default value
+            [ -z "$tag" ] && tag="default"
+            # Remove any leading "./"
+            dockerfile=$(echo "$file" | sed 's|^\./||')
+            matrix="$matrix$sep{\"dockerfile\":\"$dockerfile\",\"image_tag\":\"$tag\"}"
+            sep=","
+          done
+          matrix="$matrix]}"
+          echo "Generated matrix: $matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   security-scan:
+    needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        playwright: [ "1.50.1", "1.49.1" ]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     permissions:
       contents: write
       packages: write
@@ -34,9 +66,9 @@ jobs:
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
-          file: Dockerfile-pw-${{ matrix.playwright }}
+          file: Dockerfile.${{ matrix.playwright }}
           load: true  # Load the image locally instead of pushing
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-security
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -87,43 +119,3 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
           config: .container-structure-test.yaml
-
-      # - name: Update README with security results
-      #   if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-      #   run: |
-      #     # Get current date
-      #     DATE=$(date '+%Y-%m-%d')
-          
-      #     # Process results and create summary
-      #     TRIVY_VULNS=$(jq '.Results[].Vulnerabilities | length // 0' trivy-results.json | jq -s 'add // 0')
-      #     HADOLINT_ISSUES=$(jq '. | length // 0' hadolint-results.json)
-      #     DOCKLE_ISSUES=$(jq '.Failures | length // 0' dockle-results.json)
-          
-      #     # Create security section
-      #     SECURITY_SECTION="## Security Scan Results\n\nLast updated: ${DATE}\n\n"
-      #     SECURITY_SECTION+="| Tool | Status | Issues |\n"
-      #     SECURITY_SECTION+="| ---- | ------ | ------ |\n"
-      #     SECURITY_SECTION+="| Trivy | ${{ steps.trivy.outcome == 'success' && '✅' || '⚠️' }} | ${TRIVY_VULNS} vulnerabilities |\n"
-      #     SECURITY_SECTION+="| Hadolint | ${{ steps.hadolint.outcome == 'success' && '✅' || '⚠️' }} | ${HADOLINT_ISSUES} issues |\n"
-      #     SECURITY_SECTION+="| Dockle | ${{ steps.dockle.outcome == 'success' && '✅' || '⚠️' }} | ${DOCKLE_ISSUES} warnings |\n"
-      #     SECURITY_SECTION+="| Container Structure | ${{ steps.container_test.outcome == 'success' && '✅' || '⚠️' }} | - |\n"
-          
-      #     # Update README.md
-      #     if grep -q "## Security Scan Results" README.md; then
-      #       # Replace existing section
-      #       sed -i "/## Security Scan Results/,/^##/c\\${SECURITY_SECTION}" README.md
-      #     else
-      #       # Add new section before the first ## or at the end if no ## exists
-      #       if grep -q "^##" README.md; then
-      #         sed -i "0,/^##/{/^##/i\\${SECURITY_SECTION}\\n}" README.md
-      #       else
-      #         echo -e "\n${SECURITY_SECTION}" >> README.md
-      #       fi
-      #     fi
-          
-      #     # Commit and push changes
-      #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
-      #     git config --local user.name "github-actions[bot]"
-      #     git add README.md
-      #     git commit -m "docs: update security scan results [skip ci]"
-      #     git push 

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -66,9 +66,9 @@ jobs:
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
-          file: Dockerfile.${{ matrix.playwright }}
+          file: ${{ matrix.dockerfile }}
           load: true  # Load the image locally instead of pushing
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-test-security
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -77,7 +77,7 @@ jobs:
         id: trivy
         continue-on-error: true
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-test-security
           format: 'json'
           output: 'trivy-results.json'
           ignore-unfixed: true
@@ -110,12 +110,12 @@ jobs:
         id: dockle
         continue-on-error: true
         run: |
-          dockle --format json --timeout 600s --output dockle-results.json --ignore CIS-DI-0001 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
+          dockle --format json --timeout 600s --output dockle-results.json --ignore CIS-DI-0001 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-test-security
 
       - name: Container Structure Test
         id: container_test
         continue-on-error: true
         uses: plexsystems/container-structure-test-action@v0.3.0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.playwright }}-test-security
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-test-security
           config: .container-structure-test.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -133,13 +133,10 @@ dist
 container-structure-test-linux-amd64
 
 # Security test results
-trivy-results.json
-hadolint-results.json
-dockle-results.json
+trivy-results.*.json
+hadolint-results.*.json
+dockle-results.*.json
 
 # Security tools and results
 .tools/
 .trivy-cache/
-trivy-results.json
-hadolint-results.json
-dockle-results.json

--- a/Dockerfile.1.49.1
+++ b/Dockerfile.1.49.1
@@ -8,6 +8,7 @@ ENV LC_ALL=C.UTF-8
 
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
+    default-jdk \
     jq=1.7.1-3build1 \
     && \
   rm -rf /var/lib/apt/lists/* 
@@ -24,5 +25,6 @@ WORKDIR /tmp
 RUN npm install -g $(jq -r '.dependencies | to_entries | map(.key + "@" + .value) | join(" ")' package.json) && \
   npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps && \
   rm package.json
+
 
 

--- a/Dockerfile.1.50.1
+++ b/Dockerfile.1.50.1
@@ -8,6 +8,7 @@ ENV LC_ALL=C.UTF-8
 
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
+    default-jdk \
     jq=1.7.1-3build1 \
     && \
   rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
…Playwright images

- Update Makefile to dynamically build and test multiple Dockerfiles
- Modify .gitignore to support multiple security scan result files
- Add Dockerfiles for Playwright versions 1.49.1 and 1.50.1
- Update GitHub Actions workflow to generate matrix from Dockerfiles
- Add Java version check to container structure tests