### PR TITLE
Enhance Dockerfile and tests for Azure CLI integration

### DIFF
--- a/.container-structure-test.yaml
+++ b/.container-structure-test.yaml
@@ -44,9 +44,7 @@ commandTests:
     expectedOutput: ['OpenJDK Runtime Environment']
   - name: 'azure cli availability'
     command: 'az'
-    args: [
-      "version"
-    ]
+    args: [ 'version' ]
 
 metadataTest:
   envVars: []

--- a/.container-structure-test.yaml
+++ b/.container-structure-test.yaml
@@ -42,6 +42,11 @@ commandTests:
     command: 'java'
     args: ['--version']
     expectedOutput: ['OpenJDK Runtime Environment']
+  - name: 'azure cli availability'
+    command: 'az'
+    args: [
+      "version"
+    ]
 
 metadataTest:
   envVars: []

--- a/Dockerfile.1.49.1
+++ b/Dockerfile.1.49.1
@@ -6,16 +6,28 @@ ARG PLAYWRIGHT_VERSION=1.49.1
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
     default-jdk \
     jq=1.7.1-3build1 \
+    ca-certificates=20240203 \
+    curl=8.5.0-2ubuntu10.6 \
+    apt-transport-https=2.7.14build2 \
+    lsb-release=12.0-2 \
+    gnupg=2.4.4-2ubuntu17 \
     && \
+  # Install Azure CLI
+  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  chmod go+r /etc/apt/keyrings/microsoft.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y azure-cli=2.70.0-1~noble && \
   rm -rf /var/lib/apt/lists/* && \
   npm install -g corepack@0.24.1 && \
     corepack enable pnpm && \
-    corepack enable yarn
+    corepack enable yarn 
 
 COPY package.json /ms-playwright-agent/package.json
 

--- a/Dockerfile.1.49.1
+++ b/Dockerfile.1.49.1
@@ -10,13 +10,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
-    default-jdk \
-    jq=1.7.1-3build1 \
+    apt-transport-https=2.7.14build2 \
     ca-certificates=20240203 \
     curl=8.5.0-2ubuntu10.6 \
-    apt-transport-https=2.7.14build2 \
-    lsb-release=12.0-2 \
+    default-jdk \
     gnupg=2.4.4-2ubuntu17 \
+    jq=1.7.1-3build1 \
+    lsb-release=12.0-2 \
     && \
   # Install Azure CLI
   curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \

--- a/Dockerfile.1.49.1
+++ b/Dockerfile.1.49.1
@@ -19,7 +19,7 @@ RUN apt-get update && \
     gnupg=2.4.4-2ubuntu17 \
     && \
   # Install Azure CLI
-  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
   chmod go+r /etc/apt/keyrings/microsoft.gpg && \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
   apt-get update && \

--- a/Dockerfile.1.50.1
+++ b/Dockerfile.1.50.1
@@ -11,13 +11,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
-    default-jdk \
-    jq=1.7.1-3build1 \
+    apt-transport-https=2.7.14build2 \
     ca-certificates=20240203 \
     curl=8.5.0-2ubuntu10.6 \
-    apt-transport-https=2.7.14build2 \
-    lsb-release=12.0-2 \
+    default-jdk \
     gnupg=2.4.4-2ubuntu17 \
+    jq=1.7.1-3build1 \
+    lsb-release=12.0-2 \
     && \
   # Install Azure CLI
   curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \

--- a/Dockerfile.1.50.1
+++ b/Dockerfile.1.50.1
@@ -20,7 +20,7 @@ RUN apt-get update && \
     gnupg=2.4.4-2ubuntu17 \
     && \
   # Install Azure CLI
-  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
   chmod go+r /etc/apt/keyrings/microsoft.gpg && \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
   apt-get update && \

--- a/Dockerfile.1.50.1
+++ b/Dockerfile.1.50.1
@@ -6,16 +6,29 @@ ARG PLAYWRIGHT_VERSION=1.50.1
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
     default-jdk \
     jq=1.7.1-3build1 \
+    ca-certificates=20240203 \
+    curl=8.5.0-2ubuntu10.6 \
+    apt-transport-https=2.7.14build2 \
+    lsb-release=12.0-2 \
+    gnupg=2.4.4-2ubuntu17 \
     && \
+  # Install Azure CLI
+  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  chmod go+r /etc/apt/keyrings/microsoft.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y azure-cli=2.70.0-1~noble && \
   rm -rf /var/lib/apt/lists/* && \
   npm install -g corepack@0.24.1 && \
     corepack enable pnpm && \
-    corepack enable yarn
+    corepack enable yarn 
 
 COPY package.json /ms-playwright-agent/package.json
 

--- a/Dockerfile.1.51.1
+++ b/Dockerfile.1.51.1
@@ -11,13 +11,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
-    default-jdk \
-    jq=1.7.1-3build1 \
+    apt-transport-https=2.7.14build2 \
     ca-certificates=20240203 \
     curl=8.5.0-2ubuntu10.6 \
-    apt-transport-https=2.7.14build2 \
-    lsb-release=12.0-2 \
+    default-jdk \
     gnupg=2.4.4-2ubuntu17 \
+    jq=1.7.1-3build1 \
+    lsb-release=12.0-2 \
     && \
   # Install Azure CLI
   curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \

--- a/Dockerfile.1.51.1
+++ b/Dockerfile.1.51.1
@@ -6,16 +6,29 @@ ARG PLAYWRIGHT_VERSION=1.51.1
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # hadolint ignore=DL3008
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
     default-jdk \
     jq=1.7.1-3build1 \
+    ca-certificates=20240203 \
+    curl=8.5.0-2ubuntu10.6 \
+    apt-transport-https=2.7.14build2 \
+    lsb-release=12.0-2 \
+    gnupg=2.4.4-2ubuntu17 \
     && \
-  rm -rf /var/lib/apt/lists/* && \ 
+  # Install Azure CLI
+  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  chmod go+r /etc/apt/keyrings/microsoft.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+  apt-get update && \
+  apt-get install --no-install-recommends -y azure-cli=2.70.0-1~noble && \
+  rm -rf /var/lib/apt/lists/* && \
   npm install -g corepack@0.24.1 && \
     corepack enable pnpm && \
-    corepack enable yarn
+    corepack enable yarn 
 
 COPY package.json /ms-playwright-agent/package.json
 

--- a/Dockerfile.1.51.1
+++ b/Dockerfile.1.51.1
@@ -20,7 +20,7 @@ RUN apt-get update && \
     gnupg=2.4.4-2ubuntu17 \
     && \
   # Install Azure CLI
-  curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+  curl --proto "=https" --tlsv1.2 -sSf -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
   chmod go+r /etc/apt/keyrings/microsoft.gpg && \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure-cli.list && \
   apt-get update && \


### PR DESCRIPTION
- Added installation of Azure CLI in Dockerfiles for versions 1.49.1, 1.50.1, and 1.51.1.
- Updated container structure tests to include a check for Azure CLI availability.
- Streamlined package installation commands for improved efficiency.