### PR TITLE
Add Docker login step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,6 +97,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate tag
         id: tags
         run: |


### PR DESCRIPTION
- Introduced a new step in the Docker publish workflow to log into the Docker registry using the GitHub actor's credentials and the GITHUB_TOKEN for authentication. This enhancement streamlines the image publishing process.