### PR TITLE
fix: avoid ca-certificates downgrade in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
   apt-get install --no-install-recommends -y \
     apt-transport-https=2.7.14build2 \
-    ca-certificates=20240203 \
+    ca-certificates \
     curl=8.5.* \
     default-jdk \
     gnupg=2.4.* \


### PR DESCRIPTION
## Summary
- Remove the stale exact ca-certificates package pin so newer Playwright base images can keep their installed certificate bundle.
- Fixes the post-merge Docker workflow failure for Playwright 1.61.1 caused by apt refusing to downgrade ca-certificates.

## Quality
- Ran `docker build --build-arg PLAYWRIGHT_VERSION=1.61.1 -t playwright-plus:ci-fix .` successfully.
- Verified the commit signature with `git verify-commit HEAD`.